### PR TITLE
Create MEETINGLOGS.md, closes ansible/community#19

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-# THIS IS FOR CONTRIBUTING TO THE ANSIBLE COMMUNITY TEAM.
+# THIS IS FOR CONTRIBUTING TO THE ANSIBLE COMMUNITY WORKING GROUP.
 (link to readme.md above)
 
-General information and guidelines for contributing to the Ansible community, including this team, can be found here: http://docs.ansible.com/ansible/community.html
+General information and guidelines for contributing to the Ansible community, including this Working Group, can be found here: http://docs.ansible.com/ansible/community.html
 
 ## Issues
-We use Github issues to receive and track work items and requests. (link)
+We use Github issues to [receive](https://github.com/ansible/community/issues/new) and [track](https://github.com/ansible/community/issues) work items and requests for the Ansible Community Working Group.
 
 ## Workflow and backlog
 [![Stories in Ready](https://badge.waffle.io/ansible/community.png?label=ready&title=Ready)](https://waffle.io/ansible/community)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# THIS IS FOR CONTRIBUTING TO THE ANSIBLE COMMUNITY TEAM.
+(link to readme.md above)
+
+General information and guidelines for contributing to the Ansible community, including this team, can be found here: http://docs.ansible.com/ansible/community.html
+
+## Issues
+We use Github issues to receive and track work items and requests. (link)
+
+## Workflow and backlog
+[![Stories in Ready](https://badge.waffle.io/ansible/community.png?label=ready&title=Ready)](https://waffle.io/ansible/community)
+We use the [Ansible/communty Waffleboard](https://waffle.io/ansible/community) as a way to visualize our backlog and progress in a Kanban-style Waffleboard. While you are not required to use [waffle.io](https://waffle.io) to participate, it does provide an easy way to view the work currently in progress, as well as issues available to "adopt."
+
+## Pull Requests
+This repository accepts PRs for things that are, or should be, in this repository.
+
+We don't really have a "release process" for this repository, and thus, we don't have any information about how we do releases, or expanded information about why we picked one git management philosophy over another.

--- a/MEETINGLOGS.md
+++ b/MEETINGLOGS.md
@@ -1,9 +1,16 @@
 Ansible Community Meeting Logs
 ==============================
 
-List of logs from meetings in #ansible-meeting, as well as links to meeting notes, etherpads, and videos from in-person meetings of the contributors to the Ansible community.
+Information about logs from meetings in #ansible-meeting, as well as links to meeting notes, etherpads, and videos from in-person meetings of the contributors to the Ansible community.
 
-Past Meetings
-=============
+#ansible-meeting IRC Logs
+=========================
+The #ansible-meeting bot is graciously provided to us by our friends in the [Fedora Project community](https://fedoraproject.org). The bot, Zodbot, is a [Meetbot](https://wiki.debian.org/MeetBot) IRC bot.
+
+All *meeting* logs from #ansible-meeting can be seen [here](https://meetbot.fedoraproject.org/sresults/?group_id=ansible-meeting&type=channel). No other logs are recorded.
+
+
+Past In-person Meetings
+=======================
 
 * 2016/02/17: Ansible Contributor Summit -- [Etherpad, with summary and pre-planning](https://public.etherpad-mozilla.org/p/ansible-summit); [IRC log](https://gist.github.com/gregdek/4ed5bd745881570a17db); [Video 1, ](https://www.youtube.com/watch?v=l7v7RSHwGhk)[Video 2, ](https://www.youtube.com/watch?v=47vidc1P-ZE)[Video 3, ](https://www.youtube.com/watch?v=c3WNhsHW7Xc)[Video 4](https://www.youtube.com/watch?v=qPuQ-UToen0)

--- a/MEETINGLOGS.md
+++ b/MEETINGLOGS.md
@@ -1,0 +1,9 @@
+Ansible Community Meeting Logs
+==============================
+
+List of logs from meetings in #ansible-meeting, as well as links to meeting notes, etherpads, and videos from in-person meetings of the contributors to the Ansible community.
+
+Past Meetings
+=============
+
+* 2016/02/17: Ansible Contributor Summit -- [Etherpad, with summary and pre-planning](https://public.etherpad-mozilla.org/p/ansible-summit); [IRC log](https://gist.github.com/gregdek/4ed5bd745881570a17db); [Video 1, ](https://www.youtube.com/watch?v=l7v7RSHwGhk)[Video 2, ](https://www.youtube.com/watch?v=47vidc1P-ZE)[Video 3, ](https://www.youtube.com/watch?v=c3WNhsHW7Xc)[Video 4](https://www.youtube.com/watch?v=qPuQ-UToen0)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,63 @@
-[![Stories in Ready](https://badge.waffle.io/ansible/community.png?label=ready&title=Ready)](https://waffle.io/ansible/community)
 # community
 This repository is for management of all Ansible community related initiatives.
+
+## What We Do:
+We help to support and grow Ansible's community of contributors in their efforts to improve Ansible code, content, outreach, and user and contributor experiences.
+
+This repository serves as a space to manage tools used by the Ansible community,, monitor progress on new initiatives, and handle requests for resources or help by various teams in the wider Ansible community.
+
+## Our Goals:
+* Encourage transparency, collaboration, and accountability through tooling and lightweight project tracking and/or management
+* Provide guidance and advice to other teams in the Ansible community
+* Facilitate the creation of new initiatives and teams
+* Do all of this by KEEPING THINGS SIMPLE (just like Ansible!).
+
+## Infrastructure and processes we build and/or support:
+* Ansibullbot: (repo link) Automation (or aspiring automation) of GitHub pull request processing for ansible/ansible, ansible/ansible-modules-core, and ansible/ansible-modules-extras.
+* Meetings: IRC meeting-related infrastructure, including the meeting bot and space for logs; organization of Ansible Contributor Summits.
+
+## Teams we help:
+* Ansible (ansible, core, extras)
+* Ambassadors
+
+## Communication:
+* IRC: #ansible-devel
+* Mailing list: ??? (ansible-devel?)
+* GitHub issues: (link)
+
+## What We're Working On:
+[![Stories in Ready](https://badge.waffle.io/ansible/community.png?label=ready&title=Ready)](https://waffle.io/ansible/community)
+* New tasks and in-progress work are tracked via GitHub issues (link) in this repository (and in some cases, have accompanying pull requests).
+* Backlog and progress can also be seen on our Waffleboard, which provides a kanban-style visualization of the GitHub issues and PRs. (link)
+* Additional work items relating to enabling the Ansible community that are owned by Ansible's employed "community people" (@gregdek & @robynbergeron, github links) that were generated outside of a created GitHub issues (email requests, or things we're just doing) are tracked in this repository in the spirit of transparency.
+
+## New Issues:
+Requests for resources, tools, or help relating to the tools and communication spaces used by the Ansible Community should be added as an issue in GitHub (link).
+
+If you're not sure where to get started with a new idea relating to growing and
+supporting the Ansible Community, ask in an issue.
+
+Pull requests for content or code that will go into the Ansible/Community space
+are welcome.
+
+## I'd like to help:
+YOU ARE ADMIRA-BULL!
+
+If you'd like to help the Ansible Community Team, read CONTRIBUTING.md. Existing issues can be seen in our GitHub issues list.
+If you'd like to help improve Ansible code or modules, please see xxxx.
+If you're interested in contributing to the efforts of other Ansible teams, please refer to their contribution guidelines in their repositories.
+If you have an idea for a new initiative or team, read on!
+
+## I'd like to start a new initiative or team:
+YOU ARE INCREDI-BULL.
+
+Someday, we'll probably have more structure around this; for now, we're keeping it simple.
+
+The Ansible Community Team wants you to be able to start doing the things you want to do, so here are a few guidelines:
+
+* Look to see if anyone else has the same idea!
+* If you have an idea for the Ansible code itself, this is not the right place to make it happen. Please see (link for I have an idea or etc. in community.html docs)
+* If you have an idea THAT YOU WANT TO WORK ON that depends upon or is related to Ansible code, create an issue in this repository, and start a discussion on the ansible-devel mailing list. Encourage others who might be interested in helping to indicate their interest in the GitHub issue.
+* If you have an idea THAT YOU WANT TO WORK ON that does not relate to Ansible code, such as content, contributor enablement, outreach, or anything else you can imagine, please open an issue in this repository.
+* If you have an idea that you CAN'T WORK ON, create an issue in this repository -- but please remember that without a willing contributor wanting to do the work, many suggestions do not turn into actual results.
+* And remember: Right now, we have little process around "how to do this" -- so being transparent is the best way avoid duplication of effort, and the best way to find people to help you out. "Release early, release often," even if it's not code!

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ This repository serves as a space to manage tools used by the Ansible community,
 * Meetings: IRC meeting-related infrastructure, including the meeting bot and space for logs; organization of Ansible Contributor Summits.
 
 ## Teams we help:
-* Ansible (ansible, core, extras)
-* Ambassadors
+* Ansible (ansible, core, extras) (add links)
+* Ambassadors (add description, link)
 
 ## Communication:
 * IRC: #ansible-devel

--- a/README.md
+++ b/README.md
@@ -1,38 +1,39 @@
-# community
+# Ansible Community Working Group
 This repository is for management of all Ansible community related initiatives.
 
 ## What We Do:
 We help to support and grow Ansible's community of contributors in their efforts to improve Ansible code, content, outreach, and user and contributor experiences.
 
-This repository serves as a space to manage tools used by the Ansible community,, monitor progress on new initiatives, and handle requests for resources or help by various teams in the wider Ansible community.
+This repository serves as a space for the Ansible Community Working Group to manage tools used by the Ansible community, monitor progress on new initiatives, and handle requests for resources or help by various Working Groups in the wider Ansible community.
 
 ## Our Goals:
 * Encourage transparency, collaboration, and accountability through tooling and lightweight project tracking and/or management
-* Provide guidance and advice to other teams in the Ansible community
-* Facilitate the creation of new initiatives and teams
+* Provide guidance and advice to other working groups in the Ansible community
+* Facilitate the creation of new initiatives and Working Groups
 * Do all of this by KEEPING THINGS SIMPLE (just like Ansible!).
 
 ## Infrastructure and processes we build and/or support:
-* Ansibullbot: (repo link) Automation (or aspiring automation) of GitHub pull request processing for ansible/ansible, ansible/ansible-modules-core, and ansible/ansible-modules-extras.
-* Meetings: IRC meeting-related infrastructure, including the meeting bot and space for logs; organization of Ansible Contributor Summits.
+* [Ansibullbot](https://github.com/ansible/ansibullbot): Automation (or aspiring automation) of GitHub pull request processing for ansible/ansible, ansible/ansible-modules-core, and ansible/ansible-modules-extras.
+* [Meetings](https://github.com/ansible/community/blob/master/MEETINGLOGS.md): IRC meeting-related infrastructure, including the meeting bot and space for logs; organization of Ansible Contributor Summits.
 
-## Teams we help:
-* Ansible (ansible, core, extras) (add links)
-* Ambassadors (add description, link)
+## Groups we help:
+* Ansible development: [ansible/ansible](https://github.com/ansible/ansible), [ansible/ansible-modules-core](https://github.com/ansible/ansible-modules-core), [ansible/ansible-modules-extras](https://github.com/ansible/ansible-modules-extras)
+* [Ambassadors](https://github.com/ansible/ambassadors)
 
 ## Communication:
 * IRC: #ansible-devel
-* Mailing list: ??? (ansible-devel?)
-* GitHub issues: (link)
+* IRC Meetings: #ansible-meeting (Tuesday/Thursday, 14:00pm EST / 19:00 UTC
+* [Mailing list](https://groups.google.com/forum/#!forum/ansible-devel) 
+* [GitHub issues](https://github.com/ansible/community/issues)
 
 ## What We're Working On:
 [![Stories in Ready](https://badge.waffle.io/ansible/community.png?label=ready&title=Ready)](https://waffle.io/ansible/community)
 * New tasks and in-progress work are tracked via GitHub issues (link) in this repository (and in some cases, have accompanying pull requests).
-* Backlog and progress can also be seen on our Waffleboard, which provides a kanban-style visualization of the GitHub issues and PRs. (link)
-* Additional work items relating to enabling the Ansible community that are owned by Ansible's employed "community people" (@gregdek & @robynbergeron, github links) that were generated outside of a created GitHub issues (email requests, or things we're just doing) are tracked in this repository in the spirit of transparency.
+* Backlog and progress can also be seen on our [Waffleboard](https://waffle.io/ansible/community), which provides a kanban-style visualization of the GitHub issues and PRs. 
+* Additional work items relating to enabling the Ansible community that are owned by Ansible's Community Team ([@gregdek](https://github.com/gregdek) & [@robynbergeron](https://github.com/robynbergeron]) that were generated outside of a created GitHub issues (email requests, or things we're just doing) are tracked in this repository in the spirit of transparency.
 
 ## New Issues:
-Requests for resources, tools, or help relating to the tools and communication spaces used by the Ansible Community should be added as an issue in GitHub (link).
+Requests for resources, tools, or help relating to the tools and communication spaces used by the Ansible Community should be added as an issue in [GitHub](https://github.com/ansible/community/issues/new).
 
 If you're not sure where to get started with a new idea relating to growing and
 supporting the Ansible Community, ask in an issue.
@@ -43,9 +44,9 @@ are welcome.
 ## I'd like to help:
 YOU ARE ADMIRA-BULL!
 
-If you'd like to help the Ansible Community Team, read CONTRIBUTING.md. Existing issues can be seen in our GitHub issues list.
-If you'd like to help improve Ansible code or modules, please see xxxx.
-If you're interested in contributing to the efforts of other Ansible teams, please refer to their contribution guidelines in their repositories.
+If you'd like to help the Ansible Community Working Group, read CONTRIBUTING.md. Existing issues can be seen in our GitHub issues list.
+If you'd like to help improve Ansible code or modules, please see .
+If you're interested in contributing to the efforts of other Ansible Working Groups, please refer to their contribution guidelines in their repositories.
 If you have an idea for a new initiative or team, read on!
 
 ## I'd like to start a new initiative or team:
@@ -53,11 +54,11 @@ YOU ARE INCREDI-BULL.
 
 Someday, we'll probably have more structure around this; for now, we're keeping it simple.
 
-The Ansible Community Team wants you to be able to start doing the things you want to do, so here are a few guidelines:
+The Ansible Working Group wants you to be able to start doing the things you want to do, so here are a few guidelines:
 
 * Look to see if anyone else has the same idea!
-* If you have an idea for the Ansible code itself, this is not the right place to make it happen. Please see (link for I have an idea or etc. in community.html docs)
-* If you have an idea THAT YOU WANT TO WORK ON that depends upon or is related to Ansible code, create an issue in this repository, and start a discussion on the ansible-devel mailing list. Encourage others who might be interested in helping to indicate their interest in the GitHub issue.
-* If you have an idea THAT YOU WANT TO WORK ON that does not relate to Ansible code, such as content, contributor enablement, outreach, or anything else you can imagine, please open an issue in this repository.
-* If you have an idea that you CAN'T WORK ON, create an issue in this repository -- but please remember that without a willing contributor wanting to do the work, many suggestions do not turn into actual results.
+* If you have an idea for the Ansible code itself, this is not the right place to make it happen. Please see the [documentation for current and prospective developers] (http://docs.ansible.com/ansible/community.html#for-current-and-prospective-developers).
+* If you have an idea THAT YOU WANT TO WORK ON that depends upon or is related to Ansible code, create an issue in [this repository](https://github.com/ansible/community/issues/new), and start a discussion on the ansible-devel mailing list. Encourage others who might be interested in helping to indicate their interest in the GitHub issue.
+* If you have an idea THAT YOU WANT TO WORK ON that does not relate to Ansible code, such as content, contributor enablement, outreach, or anything else you can imagine, please open an issue in [this repository](https://github.com/ansible/community/issues/new).
+* If you have an idea that you CAN'T WORK ON, create an issue in [this repository](https://github.com/ansible/community/issues/new) -- but please remember that without a willing contributor wanting to do the work, many suggestions do not turn into actual results.
 * And remember: Right now, we have little process around "how to do this" -- so being transparent is the best way avoid duplication of effort, and the best way to find people to help you out. "Release early, release often," even if it's not code!


### PR DESCRIPTION
Creating space to capture meeting logs. Note: in the future, IRC logs could probably dump into a /meetings subdirectory that we can point to, though we would probably still keep this space around for documenting in-person events, and just link to the subdirectory to see things from #ansible-meeting.