### PR TITLE
ansible-network for meetings

### DIFF
--- a/meetings/ical/network.ics
+++ b/meetings/ical/network.ics
@@ -3,13 +3,13 @@ VERSION:2.0
 PRODID:-//yaml2ical agendas//EN
 BEGIN:VEVENT
 SUMMARY:Network working group
-DTSTART;VALUE=DATE-TIME:20170712T160000Z
+DTSTART;VALUE=DATE-TIME:20170913T160000Z
 DURATION:PT1H
 RRULE:FREQ=WEEKLY
 DESCRIPTION:Project:  Network working group\nChair:  Peter Sprygada (priva
  teip)\nDescription:  \nDiscuss everything network.\n\nAgenda URL:  https:/
  /github.com/ansible/community/issues?q=is:open+label:meeting_agenda+label:
  network\nProject URL:  https://github.com/ansible/community/wiki/Network
-LOCATION:#ansible-meeting
+LOCATION:#ansible-network
 END:VEVENT
 END:VCALENDAR

--- a/meetings/network.yaml
+++ b/meetings/network.yaml
@@ -9,5 +9,5 @@ description: |
 schedule:
 - time: '1600'
   day: Wednesday
-  irc: ansible-meeting
+  irc: ansible-network
   frequency: weekly


### PR DESCRIPTION
Now that we have meeting bot (`@zobot`) in `#ansible-network` lets move the meetings there.