### PR TITLE
Update AWS stats for December

### DIFF
--- a/group-aws/boto3.md
+++ b/group-aws/boto3.md
@@ -23,7 +23,6 @@ enforce that new features must have tests.
 
 | Module               | PR                                                     |
 |----------------------|--------------------------------------------------------|
-| ec2_ami              | [28506](https://github.com/ansible/ansible/pull/28506) |
 | ec2_metric_alarm     | [23407](https://github.com/ansible/ansible/pull/23407) |
 | ec2_scaling_policy   | [26476](https://github.com/ansible/ansible/pull/26476) |
 | ec2_vpc_net_facts    | [25375](https://github.com/ansible/ansible/pull/25375) |
@@ -32,7 +31,7 @@ enforce that new features must have tests.
 
 TODO: add many more to the above list!
 
-# State of the codebase (As at 2017-11-08)
+# State of the codebase (As at 2017-12-06)
 
 ## boto3 only
 
@@ -90,6 +89,7 @@ TODO: add many more to the above list!
 * `ecs_taskdefinition_facts`
 * `efs_facts`
 * `elasticache`
+* `elasticache_facts`
 * `elasticache_parameter_group`
 * `elasticache_snapshot`
 * `elb_application_lb`
@@ -130,11 +130,11 @@ TODO: add many more to the above list!
 
 ## boto only
 
+* `_ec2_ami_find`
 * `_ec2_remote_facts`
 * `_ec2_vpc`
 * `_ec2_vpc_dhcp_options`
 * `ec2`
-* `ec2_ami_find`
 * `ec2_eip`
 * `ec2_elb`
 * `ec2_elb_facts`

--- a/group-aws/integration.md
+++ b/group-aws/integration.md
@@ -9,6 +9,9 @@ Following the 2.4 release, all modules marked `stableinterface`
 MUST have integration tests for new features. Upgrading to boto3
 shall be considered a feature request.
 
+Following the 2.5 release, all new modules MUST have integration
+tests.
+
 Modules marked `preview` SHOULD have integration tests for new
 features.
 
@@ -35,12 +38,11 @@ There are some PRs with tests:
 # State of the codebase
 
 Existing modules with tests:
-* `aws_api_gateway`
-* `aws_lambda`
-* `aws_s3`
 * `ec2_ami`
-* `ec2_classic_lb`
+* `ec2_elb_lb`
 * `ec2_group`
 * `ec2_key`
+* `ec2_vpc_route_table`
+* `ec2_vpc_subnet`
 * `ecs_ecr`
-* `elb_classic_lb`
+* `lambda_policy`

--- a/group-aws/review.md
+++ b/group-aws/review.md
@@ -13,7 +13,9 @@ There are some discrepancies below with the numbers (you expect
 number of open issues to change by the sum of open and closed issues
 in the month). One explanation might be issues opened longer ago
 than a month but labelled with AWS in the last month. There may
-be a better explanation though.
+be a better explanation though (one such is that I was undercounting
+opened issues by ignoring issues that had been opened but since closed,
+but discrepancies still exist).
 
 | Date       | Open Issues | Open PRs | 1mo issues | 1mo PRs |
 |------------|-------------|----------|------------|---------|
@@ -21,9 +23,10 @@ be a better explanation though.
 | 2017-09-05 | 144         | 131      | +11/-27    | +20/-78 |
 | 2017-10-08 | 334         | 147      | +196/-54   | +40/-76 |
 | 2017-11-08 | 325         | 148      | +16/-48    | +28/-101 |
+| 2017-12-06 | 334         | 158      | +26/-31    | +47/-45 |
 
 
-* [Closed issues in last month (change date)](https://github.com/ansible/ansible/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20label%3Aaws%20closed%3A%3E2017-10-08)
-* [Closed PRs in last month (change date)](https://github.com/ansible/ansible/issues?utf8=%E2%9C%93&q=is%3Apr%20is%3Aclosed%20label%3Aaws%20closed%3A%3E2017-10-08)
-* [Opened issues in last month (change date)](https://github.com/ansible/ansible/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Aaws%20created%3A%3E2017-10-08)
-* [Opened PRs in last month (change date)](https://github.com/ansible/ansible/issues?utf8=%E2%9C%93&q=is%3Apr%20is%3Aopen%20label%3Aaws%20created%3A%3E2017-10-08)
+* [Closed issues in last month (change date)](https://github.com/ansible/ansible/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20label%3Aaws%20closed%3A%3E2017-11-06)
+* [Closed PRs in last month (change date)](https://github.com/ansible/ansible/issues?utf8=%E2%9C%93&q=is%3Apr%20is%3Aclosed%20label%3Aaws%20closed%3A%3E2017-11-06)
+* [Opened issues in last month (change date)](https://github.com/ansible/ansible/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3Aaws%20created%3A%3E2017-11-06) - add the open and closed numbers together
+* [Opened PRs in last month (change date)](https://github.com/ansible/ansible/issues?utf8=%E2%9C%93&q=is%3Apr%20is%3Aopen%20label%3Aaws%20created%3A%3E2017-11-06) - add the open and closed numbers together


### PR DESCRIPTION
Add stats

Also add integration test policy for new modules following release of 2.5 (don't want to arbitrarily change policy today as that would affect modules currently progress).