### PR TITLE
Tidy up IRC & Group list

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,25 @@
 
 This repository is for management of all Ansible community related initiatives.
 
-## What We Do:
-
 We help to support and grow Ansible's community of contributors in their efforts to improve Ansible code, content, outreach, and user and contributor experiences.
 
 This repository serves as a space for the Ansible Community Working Group to manage tools used by the Ansible community, monitor progress on new initiatives, and handle requests for resources or help by various Working Groups in the wider Ansible community.
 
-## Our Goals:
+## Our Goals
 
 * Encourage transparency, collaboration, and accountability through tooling and lightweight project tracking and/or management
 * Provide guidance and advice to other working groups in the Ansible community
 * Facilitate the creation of new initiatives and Working Groups
 * Do all of this by KEEPING THINGS SIMPLE (just like Ansible!).
 
-## Infrastructure and processes we build and/or support:
+## Infrastructure and processes we build and/or support
 
 * [Ansibullbot](https://github.com/ansible/ansibullbot): Automation (or aspiring automation) of GitHub pull request processing for ansible/ansible, ansible/ansible-modules-core, and ansible/ansible-modules-extras.
 * [Meetings](https://github.com/ansible/community/tree/master/meetings): IRC meeting-related infrastructure, including the meeting bot and space for logs; organization of Ansible Contributor Summits.
 
 ## Groups
+
+**NOTE:** For the majority of IRC channels you must [register your nick with Freenode](https://freenode.net/kb/answer/registration)
 
 The following lists the `IRC` channels, and groups documentation
 * `#ansible` General **user** discussion
@@ -29,7 +29,7 @@ The following lists the `IRC` channels, and groups documentation
   - `#ansible-aws` [AWS Working Group](https://github.com/ansible/community/tree/master/group-aws)
   - `#ansible-awx` [AWX Working Group](https://github.com/ansible/community/tree/master/group-awx)
   - `#ansible-azure` [Azure Working Group](https://github.com/ansible/community/tree/master/group-azure)
-  - `#ansible-community` [Community Working Group](https://github.com/ansible/community/tree/master/group-community)
+  - `#ansible-community` [Community Working Group](https://github.com/ansible/community/tree/master/group-community) - everything else
   - `#ansible-community` [Contributor Experience Group](https://github.com/ansible/community/tree/master/group-contributor-experience)
   - `#ansible-container` [Container Working Group](https://github.com/ansible/community/tree/master/group-container)
   - `#ansible-galaxy` [Galaxy Working Group](https://github.com/ansible/community/tree/master/group-galaxy)
@@ -45,10 +45,11 @@ The following lists the `IRC` channels, and groups documentation
 * `#ansible-community` [Ambassadors](https://github.com/ansible/ambassadors)
 * `#ansible-meeting` General meeting location [Meeting Schedule and logs](https://github.com/ansible/community/blob/master/meetings)
 
-## Communication:
-* Language specific groups
+## Communication
+
+* Language specific
   * IRC: `#ansible-es` - Channel for Spanish speaking Ansible community
-  * IRC: `#ansibleeu` - Channel for european Ansible community
+  * IRC: `#ansibleeu` - Channel for European Ansible community
   * IRC: `#ansible-fr` - Channel for French speaking Ansible community
   * IRC: `#ansiblezh` - Channel for Zurich Ansible community
 * Mailing Lists
@@ -59,7 +60,7 @@ The following lists the `IRC` channels, and groups documentation
   * [Ansible Lockdown](https://groups.google.com/forum/m/#!forum/ansible-lockdown)
   * [Molecule](https://groups.google.com/forum/#!forum/molecule-users)
 
-## What We're Working On:
+## What We're Working On
 
 * [Community Project](https://github.com/ansible/community/projects/1)
 * [Contributor Experience Project](https://github.com/orgs/ansible/projects/2)

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ The following lists the `IRC` channels, and groups documentation
   - `#ansible-container` [Container Working Group](https://github.com/ansible/community/tree/master/group-container)
   - `#ansible-galaxy` [Galaxy Working Group](https://github.com/ansible/community/tree/master/group-galaxy)
   - `#ansible-docs` [Documentation Working Group](https://github.com/ansible/community/tree/master/group-docs)
-
   - `#ansible-jboss` [JBoss Working Group](https://github.com/ansible/community/tree/master/group-jboss)
   - `#ansible-lightbulb` [Lightbulb Training](https://github.com/ansible/lightbulb)
   - `#ansible-lockdown` [Ansible playbook roles for security](https://ansiblelockdown.io/) [gh/ansible/ansible-lockdown](https://github.com/ansible/ansible-lockdown)
+  - `#molecule-users` designed to aid in the development and testing of Ansible roles
   - `#ansible-network` [Network Working Group](https://github.com/ansible/community/tree/master/group-network)
   - `#ansible-devel` [Testing Working Group](https://github.com/ansible/community/tree/master/group-testing)
   - `#ansible-vmwae` [VMware Working Group](https://github.com/ansible/community/tree/master/group-vmware)
@@ -57,6 +57,7 @@ The following lists the `IRC` channels, and groups documentation
   * [Ansible Devel](https://groups.google.com/forum/#!forum/ansible-devel)
   * [Ansible Outreach inc Meetups](https://groups.google.com/forum/#!forum/ansible-outreach)
   * [Ansible Lockdown](https://groups.google.com/forum/m/#!forum/ansible-lockdown)
+  * [Molecule](https://groups.google.com/forum/#!forum/molecule-users)
 
 ## What We're Working On:
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ The following lists the `IRC` channels, and groups documentation
   * [Release Announcements](https://groups.google.com/forum/#!forum/ansible-announce) - low traffic, please subscribe
   * [Ansible Project (User)](https://groups.google.com/forum/#!forum/ansible-project)
   * [Ansible Devel](https://groups.google.com/forum/#!forum/ansible-devel)
-  * [Ansible outreach inc Meetups](https://groups.google.com/forum/#!forum/ansible-outreach)
+  * [Ansible Outreach inc Meetups](https://groups.google.com/forum/#!forum/ansible-outreach)
+  * [Ansible Lockdown](https://groups.google.com/forum/m/#!forum/ansible-lockdown)
 
 ## What We're Working On:
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ The following lists the `IRC` channels, and groups documentation
   * IRC: `#ansible-fr` - Channel for French speaking Ansible community
   * IRC: `#ansiblezh` - Channel for Zurich Ansible community
 * Mailing Lists
-  * [Release Announcements](https://groups.google.com/forum/#!forum/ansible-announce) - low traffic, please subscribe
+  * [Ansible Release Announcements](https://groups.google.com/forum/#!forum/ansible-announce) - low traffic, please subscribe
   * [Ansible Project (User)](https://groups.google.com/forum/#!forum/ansible-project)
+  * [Ansible AWX](https://groups.google.com/forum/#!forum/awx-project)
   * [Ansible Devel](https://groups.google.com/forum/#!forum/ansible-devel)
   * [Ansible Outreach inc Meetups](https://groups.google.com/forum/#!forum/ansible-outreach)
   * [Ansible Lockdown](https://groups.google.com/forum/m/#!forum/ansible-lockdown)

--- a/README.md
+++ b/README.md
@@ -1,91 +1,72 @@
 # Ansible Community Working Group
+
 This repository is for management of all Ansible community related initiatives.
 
 ## What We Do:
+
 We help to support and grow Ansible's community of contributors in their efforts to improve Ansible code, content, outreach, and user and contributor experiences.
 
 This repository serves as a space for the Ansible Community Working Group to manage tools used by the Ansible community, monitor progress on new initiatives, and handle requests for resources or help by various Working Groups in the wider Ansible community.
 
 ## Our Goals:
+
 * Encourage transparency, collaboration, and accountability through tooling and lightweight project tracking and/or management
 * Provide guidance and advice to other working groups in the Ansible community
 * Facilitate the creation of new initiatives and Working Groups
 * Do all of this by KEEPING THINGS SIMPLE (just like Ansible!).
 
 ## Infrastructure and processes we build and/or support:
+
 * [Ansibullbot](https://github.com/ansible/ansibullbot): Automation (or aspiring automation) of GitHub pull request processing for ansible/ansible, ansible/ansible-modules-core, and ansible/ansible-modules-extras.
 * [Meetings](https://github.com/ansible/community/tree/master/meetings): IRC meeting-related infrastructure, including the meeting bot and space for logs; organization of Ansible Contributor Summits.
 
-## Groups we help:
-* Ansible development: [ansible/ansible](https://github.com/ansible/ansible)
+## Groups
+
+The following lists the `IRC` channels, and groups documentation
+* `#ansible` General **user** discussion
+* `#ansible-devel` Ansible **development** discussion [ansible/ansible](https://github.com/ansible/ansible)
 * Working Groups
-  - [AWS Working Group](https://github.com/ansible/community/tree/master/group-aws)
-  - [Azure Working Group](https://github.com/ansible/community/tree/master/group-azure)
-  - [Community Working Group](https://github.com/ansible/community/tree/master/group-community)
-  - [Contributor Experience Group](https://github.com/ansible/community/tree/master/group-contributor-experience)
-  - [Container Working Group](https://github.com/ansible/community/tree/master/group-container)
-  - [Galaxy Working Group](https://github.com/ansible/community/tree/master/group-galaxy)
-  - [Network Working Group](https://github.com/ansible/community/tree/master/group-network)
-  - [Testing Working Group](https://github.com/ansible/community/tree/master/group-testing)
-  - [VMware Working Group](https://github.com/ansible/community/tree/master/group-vmware)
-  - [Windows Working Group](https://github.com/ansible/community/tree/master/group-windows)
-* [Ambassadors](https://github.com/ansible/ambassadors)
+  - `#ansible-aws` [AWS Working Group](https://github.com/ansible/community/tree/master/group-aws)
+  - `#ansible-awx` [AWX Working Group](https://github.com/ansible/community/tree/master/group-awx)
+  - `#ansible-azure` [Azure Working Group](https://github.com/ansible/community/tree/master/group-azure)
+  - `#ansible-community` [Community Working Group](https://github.com/ansible/community/tree/master/group-community)
+  - `#ansible-community` [Contributor Experience Group](https://github.com/ansible/community/tree/master/group-contributor-experience)
+  - `#ansible-container` [Container Working Group](https://github.com/ansible/community/tree/master/group-container)
+  - `#ansible-galaxy` [Galaxy Working Group](https://github.com/ansible/community/tree/master/group-galaxy)
+  - `#ansible-docs` [Documentation Working Group](https://github.com/ansible/community/tree/master/group-docs)
+
+  - `#ansible-jboss` [JBoss Working Group](https://github.com/ansible/community/tree/master/group-jboss)
+  - `#ansible-lightbulb` [Lightbulb Training](https://github.com/ansible/lightbulb)
+  - `#ansible-lockdown` [Ansible playbook roles for security](https://ansiblelockdown.io/) [gh/ansible/ansible-lockdown](https://github.com/ansible/ansible-lockdown)
+  - `#ansible-network` [Network Working Group](https://github.com/ansible/community/tree/master/group-network)
+  - `#ansible-devel` [Testing Working Group](https://github.com/ansible/community/tree/master/group-testing)
+  - `#ansible-vmwae` [VMware Working Group](https://github.com/ansible/community/tree/master/group-vmware)
+  - `#ansible-windows` [Windows Working Group](https://github.com/ansible/community/tree/master/group-windows)
+* `#ansible-community` [Ambassadors](https://github.com/ansible/ambassadors)
+* `#ansible-meeting` General meeting location [Meeting Schedule and logs](https://github.com/ansible/community/blob/master/meetings)
 
 ## Communication:
-Find us on Freenode:
-* IRC: #ansible - General Discussion
-* IRC: #ansible-devel - Channel for discussing pull-requests and contributions only
-* IRC: #ansible-notice - Automated messages from various services related to Ansible
-* IRC: #ansible-meeting - Ansible community meeting channel. [Meeting Schedule and logs](https://github.com/ansible/community/blob/master/meetings)
-* IRC: #ansible-aws - Channel for discussing AWS and Ansible related things
-* IRC: #ansible-awx - Channel for discussing AWX (upstream Tower) related things
-* IRC: #ansible-azure - Channel for discussing Azure and Ansible related things
-* IRC: #ansible-community - Channel for discussing Ansible Community & contributor experience related things
-* IRC: #ansible-container - Channel for discussing Containers and Ansible related things
-* IRC: #ansible-galaxy - Channel for discussing Ansible Galaxy related things
-* IRC: #ansible-jboss - Channel for discussing JBoss and Ansible related things
-* IRC: #ansible-network - Channel for discussing Network and Ansible related things
-* IRC: #ansible-news - Channel for discussing Ansible Communication & News related things
-* IRC: #ansible-vmware - Channel for discussing VMware and Ansible related things
-* IRC: #ansible-windows - Channel for discussing Windows and Ansible related things
-* IRC: #ansible-es - Channel for Spanish speaking Ansible community
-* IRC: #ansible-fr - Channel for French speaking Ansible community
-* [Mailing list](https://groups.google.com/forum/#!forum/ansible-devel)
-* [GitHub issues](https://github.com/ansible/community/issues)
+* Language specific groups
+  * IRC: `#ansible-es` - Channel for Spanish speaking Ansible community
+  * IRC: `#ansibleeu` - Channel for european Ansible community
+  * IRC: `#ansible-fr` - Channel for French speaking Ansible community
+  * IRC: `#ansiblezh` - Channel for Zurich Ansible community
+* Mailing Lists
+  * [Release Announcements](https://groups.google.com/forum/#!forum/ansible-announce) - low traffic, please subscribe
+  * [Ansible Project (User)](https://groups.google.com/forum/#!forum/ansible-project)
+  * [Ansible Devel](https://groups.google.com/forum/#!forum/ansible-devel)
+  * [Ansible outreach inc Meetups](https://groups.google.com/forum/#!forum/ansible-outreach)
 
 ## What We're Working On:
-[![Stories in Ready](https://badge.waffle.io/ansible/community.png?label=ready&title=Ready)](https://waffle.io/ansible/community)
-* New tasks and in-progress work are tracked via GitHub issues (link) in this repository (and in some cases, have accompanying pull requests).
-* Backlog and progress can also be seen on our [Waffleboard](https://waffle.io/ansible/community), which provides a kanban-style visualization of the GitHub issues and PRs.
-* Additional work items relating to enabling the Ansible community that are owned by Ansible's Community Team ([@gregdek](https://github.com/gregdek) & [@robynbergeron](https://github.com/robynbergeron]) that were generated outside of a created GitHub issues (email requests, or things we're just doing) are tracked in this repository in the spirit of transparency.
 
-## New Issues:
-Requests for resources, tools, or help relating to the tools and communication spaces used by the Ansible Community should be added as an issue in [GitHub](https://github.com/ansible/community/issues/new).
+* [Community Project](https://github.com/ansible/community/projects/1)
+* [Contributor Experience Project](https://github.com/orgs/ansible/projects/2)
 
-If you're not sure where to get started with a new idea relating to growing and
-supporting the Ansible Community, ask in an issue.
-
-Pull requests for content or code that will go into the Ansible/Community space
-are welcome.
-
-## I'd like to help:
-YOU ARE ADMIRA-BULL!
-
-If you'd like to help the Ansible Community Working Group, read CONTRIBUTING.md. Existing issues can be seen in our GitHub issues list.
-If you'd like to help improve Ansible code or modules, please see .
-If you're interested in contributing to the efforts of other Ansible Working Groups, please refer to their contribution guidelines in their repositories.
-If you have an idea for a new initiative or team, read on!
 
 ## I'd like to start a new initiative or team:
-YOU ARE INCREDI-BULL.
 
-Someday, we'll probably have more structure around this; for now, we're keeping it simple.
+* [Creating a Working Group](WORKING-GROUPS.md)
 
-The Ansible Working Group wants you to be able to start doing the things you want to do, so here are a few guidelines:
+## Speak to us
 
-* Look to see if anyone else has the same idea!
-* If you have an idea for the Ansible code itself, this is not the right place to make it happen. Please see the [documentation for current and prospective developers](http://docs.ansible.com/ansible/community.html#for-current-and-prospective-developers).
-* If you have an idea THAT YOU WANT TO WORK ON that depends upon or is related to Ansible code, create an issue in [this repository](https://github.com/ansible/ansible/issues/new), and start a discussion on the ansible-devel mailing list. Encourage others who might be interested in helping to indicate their interest in the GitHub issue.
-* If you have an idea THAT YOU WANT TO WORK ON that does not relate to Ansible code, such as content, contributor enablement, outreach, or anything else you can imagine, please open an issue in [this repository](https://github.com/ansible/community/issues/new).
-* If you have an idea that you CAN'T WORK ON, create an issue in [this repository](https://github.com/ansible/community/issues/new) -- but please remember that without a willing contributor wanting to do the work, many suggestions do not turn into actual results.
-* And remember: Right now, we have little process around "how to do this" -- so being transparent is the best way avoid duplication of effort, and the best way to find people to help you out. "Release early, release often," even if it's not code!
+Join us in `#ansible-community` on Freenode


### PR DESCRIPTION
* We are using GitHub project boards, not waffle boards
* Remove old contributing info
* Combine groups & IRC channels sections plus add docs, linode, Galaxy
* List all IRC channels `/msg alis LIST #ansible*`