### PR TITLE
Add rmcintosh to the wiki listing for Linode.

### DIFF
--- a/group-linode/README.md
+++ b/group-linode/README.md
@@ -26,6 +26,7 @@ Upcoming
 * [Dan O'Brien](https://github.com/intheclouddan), intheclouddan[m]
 * [lwm](https://github.com/lwm), decentral1se
 * [Marques Johansson](https://github.com/displague), marques
+* [rmcintosh](https://github.com/rmcintosh), mcintosh
 
 ## Active Members
 


### PR DESCRIPTION
Follows https://github.com/ansible/ansible/pull/46642.

cc @rmcintosh.