### PR TITLE
typo: Digital Ocean --> DigitalOcean

### DIFF
--- a/decks/intro-to-ansible-tower.html
+++ b/decks/intro-to-ansible-tower.html
@@ -322,7 +322,7 @@ $ wget https://bit.ly/ansibletowerbundle
               <li>Dynamic and static inventory sources can be used together</li>
             </ul>
             <aside class="notes">
-              <p>Ansible can take inventory from a wide variety of sources on-the-fly. It can draw from many different systems such as VMWare, Openstack, Amazon EC2, Digital Ocean, and other provisioning systems like Cobbler. You can also create your own inventory module to interface with any proprietary or in-house CMDB systems.</p>
+              <p>Ansible can take inventory from a wide variety of sources on-the-fly. It can draw from many different systems such as VMWare, Openstack, Amazon EC2, DigitalOcean, and other provisioning systems like Cobbler. You can also create your own inventory module to interface with any proprietary or in-house CMDB systems.</p>
               <p>Ideally, the source of data for our dynamic inventory scripts is 100% correct, and is automatically updated as infrastructure changes. This is especially useful in environments where machines are coming on and offline all the time, like a cloud or virtual environment.</p>
             </aside>
           </section>


### PR DESCRIPTION
There is no space in the official brand name, DigitalOcean. :)