### PR TITLE
read_minutes: do not cut off multiline actions

### DIFF
--- a/meetings/read_minutes.py
+++ b/meetings/read_minutes.py
@@ -71,10 +71,16 @@ def format_topics(summary):
 
 def format_actions(action_items):
     actions = []
+    last_action = None
     for line in action_items.split("\n"):
         if line.startswith("* "):
             assignee, action = line[2:].split(" ", 1)
+            last_action = len(actions)
             actions.append(f"- [ ] @{assignee} {action}")
+        elif line.startswith("  ") and last_action is not None:
+            actions[last_action] += f" {line[2:]}"
+        else:
+            last_action = None
 
     if any(actions):
         actions = ["Actions", "-------", ""] + actions


### PR DESCRIPTION
For example most of the actions in https://meetbot-raw.fedoraproject.org/ansible-community/2020-07-22/ansible_community_meeting.2020-07-22-18.00.txt need two lines. The script only extracts the first line.

CC @samccann @gundalow 