### PR TITLE
Remove extra lines in iCalendar Object

### DIFF
--- a/ansible_community_meetings.ics
+++ b/ansible_community_meetings.ics
@@ -162,10 +162,6 @@ DESCRIPTION:Project:  Windows working group\nChair:  Matt Davis (nitzmahon
  m/ansible/community/wiki/Windows
 LOCATION:#ansible-windows
 END:VEVENT
-END:VCALENDAR
-BEGIN:VCALENDAR
-VERSION:2.0
-PRODID:-//yaml2ical agendas//EN
 BEGIN:VEVENT
 SUMMARY:Diversity and Inclusion working group
 DTSTART;VALUE=TIME:20210107T190000Z


### PR DESCRIPTION
D&I meeting was added as a separate calendar rather than just a separate event in the main calendar. Fixes the copy-paste error.