### PR TITLE
Update Ansible Core weekly meetings

### DIFF
--- a/ansible_community_meetings.ics
+++ b/ansible_community_meetings.ics
@@ -44,46 +44,10 @@ LOCATION:#ansible-community
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:Core Team meeting
-DTSTART;VALUE=DATE-TIME:20170718T190000Z
+DTSTART;VALUE=DATE-TIME:20170214T190000Z
 DURATION:PT1H
-DTSTAMP;VALUE=DATE-TIME:20210225T145638Z
-UID:coreteammeeting-20170718
-RRULE:FREQ=WEEKLY;UNTIL=20210312T000000Z
-DESCRIPTION:Project:  Core Team meeting\nChair:  John Barker (gundalow)\nD
- escription:  \nA place to get input from the Ansible Core Team issues\, PR
- s and proposals\nthat people who are willing to come to the meeting want t
- o present.\n- Old PRs that need attention from us (as opposed to from the
- submitter)\n- Selected proposals from the ansible/proposals repo\n- Review
-  of actions from previous meeting\n- Open discussion driven by the group\n
- \nAgenda URL:  https://github.com/ansible/community/issues?q=is:open+label
- :meeting_agenda+label:core\nProject URL:  https://github.com/ansible/commu
- nity/wiki
-LOCATION:#ansible-meeting
-END:VEVENT
-BEGIN:VEVENT
-SUMMARY:Core Team meeting
-DTSTART;VALUE=DATE-TIME:20170713T150000Z
-DURATION:PT1H
-DTSTAMP;VALUE=DATE-TIME:20210225T145638Z
-UID:coreteammeeting-20170713
-RRULE:FREQ=WEEKLY;UNTIL=20210312T000000Z
-DESCRIPTION:Project:  Core Team meeting\nChair:  John Barker (gundalow)\nD
- escription:  \nA place to get input from the Ansible Core Team issues\, PR
- s and proposals\nthat people who are willing to come to the meeting want t
- o present.\n- Old PRs that need attention from us (as opposed to from the
- submitter)\n- Selected proposals from the ansible/proposals repo\n- Review
-  of actions from previous meeting\n- Open discussion driven by the group\n
- \nAgenda URL:  https://github.com/ansible/community/issues?q=is:open+label
- :meeting_agenda+label:core\nProject URL:  https://github.com/ansible/commu
- nity/wiki
-LOCATION:#ansible-meeting
-END:VEVENT
-BEGIN:VEVENT
-SUMMARY:Core Team meeting
-DTSTART;VALUE=DATE-TIME:20210323T190000Z
-DURATION:PT1H
-DTSTAMP;VALUE=DATE-TIME:20210225T145638Z
-UID:coreteammeeting-20210323
+DTSTAMP;VALUE=DATE-TIME:20210324T163859Z
+UID:coreteammeeting-20170214
 RRULE:FREQ=WEEKLY;INTERVAL=2
 DESCRIPTION:Project:  Core Team meeting\nChair:  John Barker (gundalow)\nD
  escription:  \nA place to get input from the Ansible Core Team issues\, PR
@@ -98,10 +62,10 @@ LOCATION:#ansible-meeting
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:Core Team meeting
-DTSTART;VALUE=DATE-TIME:20210318T150000Z
+DTSTART;VALUE=DATE-TIME:20170209T150000Z
 DURATION:PT1H
-DTSTAMP;VALUE=DATE-TIME:20210225T145638Z
-UID:coreteammeeting-20210318
+DTSTAMP;VALUE=DATE-TIME:20210324T163859Z
+UID:coreteammeeting-20170209
 RRULE:FREQ=WEEKLY;INTERVAL=2
 DESCRIPTION:Project:  Core Team meeting\nChair:  John Barker (gundalow)\nD
  escription:  \nA place to get input from the Ansible Core Team issues\, PR
@@ -113,6 +77,10 @@ DESCRIPTION:Project:  Core Team meeting\nChair:  John Barker (gundalow)\nD
  :meeting_agenda+label:core\nProject URL:  https://github.com/ansible/commu
  nity/wiki
 LOCATION:#ansible-meeting
+END:VEVENT
+BEGIN:VEVENT
+DURATION:PT1H
+RRULE:FREQ=WEEKLY;INTERVAL=2
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:Documentation working group

--- a/meetings/core-team.yaml
+++ b/meetings/core-team.yaml
@@ -12,26 +12,13 @@ description: |
   - Review of actions from previous meeting
   - Open discussion driven by the group
 schedule:
-# Old schedule. Can be deleted after 2021-03-15
 - time: '1900'
   day: Tuesday
-  irc: ansible-meeting
-  frequency: weekly
-  start_date: 20170712
-- time: '1500'
-  day: Thursday
-  irc: ansible-meeting
-  frequency: weekly
-  start_date: 20170712
-
-# New schedule. Adjust start date to 20170212 when deleting previous schedule.
-- time: '1900'
-  day: Tuesday
-  irc: ansible-meeting
-  frequency: biweekly-even
-  start_date: 20210315
-- time: '1500'
-  day: Thursday
   irc: ansible-meeting
   frequency: biweekly-odd
-  start_date: 20210315
+  start_date: 20170201
+- time: '1500'
+  day: Thursday
+  irc: ansible-meeting
+  frequency: biweekly-even
+  start_date: 20170201

--- a/meetings/ical/core-team.ics
+++ b/meetings/ical/core-team.ics
@@ -3,46 +3,10 @@ VERSION:2.0
 PRODID:-//yaml2ical agendas//EN
 BEGIN:VEVENT
 SUMMARY:Core Team meeting
-DTSTART;VALUE=DATE-TIME:20170718T190000Z
+DTSTART;VALUE=DATE-TIME:20170214T190000Z
 DURATION:PT1H
-DTSTAMP;VALUE=DATE-TIME:20210225T145638Z
-UID:coreteammeeting-20170718
-RRULE:FREQ=WEEKLY;UNTIL=20210312T000000Z
-DESCRIPTION:Project:  Core Team meeting\nChair:  John Barker (gundalow)\nD
- escription:  \nA place to get input from the Ansible Core Team issues\, PR
- s and proposals\nthat people who are willing to come to the meeting want t
- o present.\n- Old PRs that need attention from us (as opposed to from the
- submitter)\n- Selected proposals from the ansible/proposals repo\n- Review
-  of actions from previous meeting\n- Open discussion driven by the group\n
- \nAgenda URL:  https://github.com/ansible/community/issues?q=is:open+label
- :meeting_agenda+label:core\nProject URL:  https://github.com/ansible/commu
- nity/wiki
-LOCATION:#ansible-meeting
-END:VEVENT
-BEGIN:VEVENT
-SUMMARY:Core Team meeting
-DTSTART;VALUE=DATE-TIME:20170713T150000Z
-DURATION:PT1H
-DTSTAMP;VALUE=DATE-TIME:20210225T145638Z
-UID:coreteammeeting-20170713
-RRULE:FREQ=WEEKLY;UNTIL=20210312T000000Z
-DESCRIPTION:Project:  Core Team meeting\nChair:  John Barker (gundalow)\nD
- escription:  \nA place to get input from the Ansible Core Team issues\, PR
- s and proposals\nthat people who are willing to come to the meeting want t
- o present.\n- Old PRs that need attention from us (as opposed to from the
- submitter)\n- Selected proposals from the ansible/proposals repo\n- Review
-  of actions from previous meeting\n- Open discussion driven by the group\n
- \nAgenda URL:  https://github.com/ansible/community/issues?q=is:open+label
- :meeting_agenda+label:core\nProject URL:  https://github.com/ansible/commu
- nity/wiki
-LOCATION:#ansible-meeting
-END:VEVENT
-BEGIN:VEVENT
-SUMMARY:Core Team meeting
-DTSTART;VALUE=DATE-TIME:20210323T190000Z
-DURATION:PT1H
-DTSTAMP;VALUE=DATE-TIME:20210225T145638Z
-UID:coreteammeeting-20210323
+DTSTAMP;VALUE=DATE-TIME:20210302T135925Z
+UID:coreteammeeting-20170214
 RRULE:FREQ=WEEKLY;INTERVAL=2
 DESCRIPTION:Project:  Core Team meeting\nChair:  John Barker (gundalow)\nD
  escription:  \nA place to get input from the Ansible Core Team issues\, PR
@@ -57,10 +21,10 @@ LOCATION:#ansible-meeting
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:Core Team meeting
-DTSTART;VALUE=DATE-TIME:20210318T150000Z
+DTSTART;VALUE=DATE-TIME:20170209T150000Z
 DURATION:PT1H
-DTSTAMP;VALUE=DATE-TIME:20210225T145638Z
-UID:coreteammeeting-20210318
+DTSTAMP;VALUE=DATE-TIME:20210302T135925Z
+UID:coreteammeeting-20170209
 RRULE:FREQ=WEEKLY;INTERVAL=2
 DESCRIPTION:Project:  Core Team meeting\nChair:  John Barker (gundalow)\nD
  escription:  \nA place to get input from the Ansible Core Team issues\, PR


### PR DESCRIPTION
Now that we have transitioned to alternating meetings, update the schedule with the generated output rather than relying on custom changes to the ics files.