### PR TITLE
Regenerate ics file for d&i meeting, and add README about ics files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ This repository serves as a space for the Ansible Community Working Group to man
 
 * [Creating a Working Group](WORKING-GROUPS.md)
 
+To create a new working group meeting, add a new YAML file to [Meetings](https://github.com/ansible/community/tree/main/meetings) and run [yaml2ics](https://pypi.org/project/yaml2ical/) and add the resulting file to the [ICS](https://github.com/ansible/community/tree/main/meetings/ics/) directory.  Check the ics file to ensure your meeting will run on the correct dates.  For example, if your meeting is every other week does it start on the correct week?
+
 ## Speak to us
 
 Join us in `#ansible-community` on Freenode

--- a/meetings/diversity.yaml
+++ b/meetings/diversity.yaml
@@ -10,4 +10,4 @@ schedule:
 - time: '1900'
   day: Thursday
   irc: ansible-diversity
-  frequency: biweekly-even
+  frequency: biweekly-odd

--- a/meetings/ical/diversity.ics
+++ b/meetings/ical/diversity.ics
@@ -3,10 +3,10 @@ VERSION:2.0
 PRODID:-//yaml2ical agendas//EN
 BEGIN:VEVENT
 SUMMARY:Diversity working group
-DTSTART;VALUE=DATE-TIME:20210408T190000Z
+DTSTART;VALUE=DATE-TIME:20210513T190000Z
 DURATION:PT1H
 DTSTAMP;VALUE=DATE-TIME:20210201T191434Z
-UID:diversityworkinggroup-20210408
+UID:diversityworkinggroup-20210513
 RRULE:FREQ=WEEKLY;INTERVAL=2
 DESCRIPTION:Project:  Diversity working group\nChair:  Jill Rouleau (jillr
  )\nDescription:  \nDiscuss everything related to Diversity and Inclusion i


### PR DESCRIPTION
I didn't know about yaml2ics - I hand wrote both the yaml and ics files when I first created the meeting and got the even/odd week wrong.  The community calendar has shown the meeting off a week because of this.  TIL about yaml2ics, so I fixed the files and added a readme bit about using that.  Imports as expected on a personal calendar.