### PR TITLE
Due to the takeover of freenode we're moving to a different irc network.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository serves as a space for the Ansible Community Working Group to man
 
 ## Groups
 
-**NOTE:** For the majority of IRC channels you must [register your nick with Freenode](https://freenode.net/kb/answer/registration)
+**NOTE:** For the majority of IRC channels you must [register your nick with irc.libera.chat](https://libera.chat/guides/registration)
 
 * [All Ansible Working Groups](https://github.com/ansible/community/wiki)
 * [All Ansible Email lists, IRC and Working Groups](https://docs.ansible.com/ansible/devel/community/communication.html)
@@ -38,4 +38,4 @@ This repository serves as a space for the Ansible Community Working Group to man
 
 ## Speak to us
 
-Join us in `#ansible-community` on Freenode
+Join us in `#ansible-community` on [irc.libera.chat](https://libera.chat)

--- a/WORKING-GROUPS.md
+++ b/WORKING-GROUPS.md
@@ -7,7 +7,7 @@ Working Groups are a way for Ansible community members to self-organize around p
 
 The basic components of a working group:
 * A group name and charter (why the group exists);
-* A registered IRC channel on freenode (will usually be #ansible-groupname);
+* A registered IRC channel on [irc.libera.chat](https://libera.chat/) (will usually be #ansible-groupname);
 * A group of users (at least two!) who will be driving the agenda of the working group;
 * Dedicated wiki space.
 
@@ -46,7 +46,7 @@ AT LEAST TWO INITIAL WORKING GROUP MEMBERS:
 We will ask you a few more questions if anything is unclear via the GitHub issue created above.
 
 Once we have enough information, we will set up the following infrastructure:
-* An IRC channel on freenode named "#ansible-yourgroupname", properly registered and op'd;
+* An IRC channel on libera.chat named "#ansible-yourgroupname", properly registered and op'd;
   * `*!*@ansible/owner/*    +AORefiorstv`
   * `*!*@ansible/staff/*    +Oo`
   * Group Contact set - via Jimi-C
@@ -67,4 +67,4 @@ Once we have enough information, we will set up the following infrastructure:
 
 ## Help!
 
-If you get stuck or want to know more join us in `#ansible-community` on Freenode
+If you get stuck or want to know more join us in `#ansible-community` on [irc.libera.chat](https://libera.chat/)

--- a/decks/contrib-summit-2021.03/3.0.0-community-update.html
+++ b/decks/contrib-summit-2021.03/3.0.0-community-update.html
@@ -35,8 +35,7 @@
             <pre class="language-yaml"><code>
   - name: #ansible-community on IRC
     hosts:
-      - chat.freenode.net:6697
-      - https://webchat.freenode.net/#ansible-community
+      - irc.libera.chat:6697
     vars:
       meetings: Every Wednesday @ 19:00 UTC
       agenda: https://github.com/ansible/community/issues/539
@@ -180,7 +179,7 @@
                 <li><a href="https://us19.campaign-archive.com/home/?u=56d874e027110e35dea0e03c1&id=d6635f5420" target="_blank">The Bullhorn</a> Ansible newsletter</li>
                 <li><a href="https://groups.google.com/forum/#!forum/ansible-announce" target="_blank">ansible-announce</a> mailing list</li>
                 <li><a href="https://twitter.com/Ansible" target="_blank">@Ansible</a> on Twitter</li>
-                <li><a href="https://webchat.freenode.net/#ansible-community" target="_blank">#ansible-community</a> on the freenode IRC network</li>
+                <li>#ansible-community on the <a href="https://libera.chat">libera.chat</a> IRC network</li>
             </ul>
             <p>Link to these slides (and more): <a href="https://ansible.github.io/community/decks/" target="_blank">https://ansible.github.io/community/decks/</a></p>
         </section>

--- a/decks/contributing-to-ansible.html
+++ b/decks/contributing-to-ansible.html
@@ -46,7 +46,7 @@
     roles:
       - community
       - manager
-    freenode: gundalow
+    libera_chat: gundalow
     github: gundalow
     twitter: the_gundalow
     email: gundalow@redhat.com
@@ -495,7 +495,7 @@
       - docs
       - core
       - community
-    freenode: acozine
+    libera_chat: acozine
     github: acozine
     email: acozine@redhat.com
           </pre></code>

--- a/group-aws/README.md
+++ b/group-aws/README.md
@@ -52,7 +52,7 @@ requests in the collection repositories.
 
 Planned work for both collections is tracked in the [AWS Project Board](https://github.com/orgs/ansible-collections/projects/4).
 ## Contact
-* #ansible-aws IRC channel on [libera.chat](https://irc.libera.net/)
+* #ansible-aws IRC channel on [libera.chat](https://irc.libera.chat/)
 * For security-related concerns email security@ansible.com and see our
     [security disclosure](https://www.ansible.com/security) for more
     information.

--- a/group-aws/README.md
+++ b/group-aws/README.md
@@ -52,7 +52,7 @@ requests in the collection repositories.
 
 Planned work for both collections is tracked in the [AWS Project Board](https://github.com/orgs/ansible-collections/projects/4).
 ## Contact
-* [#ansible-aws IRC channel](https://webchat.freenode.net/?channels=ansible-aws) on Freenode.net
+* #ansible-aws IRC channel on [libera.chat](https://irc.libera.net/)
 * For security-related concerns email security@ansible.com and see our
     [security disclosure](https://www.ansible.com/security) for more
     information.

--- a/group-aws/README.md
+++ b/group-aws/README.md
@@ -52,7 +52,7 @@ requests in the collection repositories.
 
 Planned work for both collections is tracked in the [AWS Project Board](https://github.com/orgs/ansible-collections/projects/4).
 ## Contact
-* #ansible-aws IRC channel on [libera.chat](https://irc.libera.chat/)
+* #ansible-aws IRC channel on [irc.libera.chat](https://libera.chat/)
 * For security-related concerns email security@ansible.com and see our
     [security disclosure](https://www.ansible.com/security) for more
     information.

--- a/group-network/network_dev_network_cli.rst
+++ b/group-network/network_dev_network_cli.rst
@@ -135,4 +135,4 @@ Once the first module has been added, subsequent modules only require the
 module code.
 
 
-For more information please join ``#ansible-network`` on Freenode IRC
+For more information please join ``#ansible-network`` on `irc.libera.chat <https://libera.chat/>`_

--- a/group-network/network_test.rst
+++ b/group-network/network_test.rst
@@ -202,4 +202,4 @@ More information can be found at http://docs.ansible.com/ansible/devel/dev_guide
 
 More info
 =========
-For more information please join ``#ansible-network`` on Freenode IRC
+For more information please join ``#ansible-network`` on `irc.libera.chat <https://libera.chat/>`_.

--- a/group-security/README.md
+++ b/group-security/README.md
@@ -40,7 +40,7 @@ requests in the main Ansible repository.
 * [Abhijeet Kasurde](https://github.com/akasurde), akasurde
 
 ## Contact
-* [#ansible-security IRC channel](https://webchat.freenode.net/?channels=ansible-security) on Freenode.net
+* #ansible-security IRC channel on [irc.libera.chat](https://libera.chat/)
 * For security-related concerns email security@ansible.com and see our
     [security disclosure](https://www.ansible.com/security) for more
     information.

--- a/meetings/README.md
+++ b/meetings/README.md
@@ -2,9 +2,9 @@
 
 ## #ansible-meeting
 
-Ansible IRC meetings are held on [freenode](https://freenode.net/).
+Ansible IRC meetings are held on [irc.libera.chat](https://libera.chat/).
 
-If you receive an error when you connect, see [Freenode’s Nickname Registration guide](https://freenode.net/kb/answer/registration) for instructions.
+If you receive an error when you connect, see [libera.chat’s Nickname Registration guide](https://libera.chat/guides/registration) for instructions.
 
 ## Schedule
 


### PR DESCRIPTION
ansible channels have moved to libera.chat.


Do not merge until it's decided that we're moving to libera.chat (as opposed to oftc or another network): https://github.com/ansible-community/community-topics/issues/19