### PR TITLE
Migrate Core IRC meetings to 1 time per month

### DIFF
--- a/ansible_community_meetings.ics
+++ b/ansible_community_meetings.ics
@@ -44,26 +44,10 @@ LOCATION:#ansible-community
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:Core Team meeting
-DTSTART;VALUE=DATE-TIME:20170214T190000Z
+DTSTART;VALUE=DATE-TIME:20220714T160000Z
 DURATION:PT1H
-RRULE:FREQ=WEEKLY;INTERVAL=2
-DESCRIPTION:Project:  Core Team meeting\nChair:  John Barker (gundalow)\nD
- escription:  \nA place to get input from the Ansible Core Team issues\, PR
- s and proposals\nthat people who are willing to come to the meeting want t
- o present.\n- Old PRs that need attention from us (as opposed to from the
- submitter)\n- Selected proposals from the ansible/proposals repo\n- Review
-  of actions from previous meeting\n- Open discussion driven by the group\n
- \nAgenda URL:  https://github.com/ansible/community/issues?q=is:open+label
- :meeting_agenda+label:core\nProject URL:  https://github.com/ansible/commu
- nity/wiki
-LOCATION:#ansible-meeting
-END:VEVENT
-BEGIN:VEVENT
-SUMMARY:Core Team meeting
-DTSTART;VALUE=DATE-TIME:20170209T150000Z
-DURATION:PT1H
-RRULE:FREQ=WEEKLY;INTERVAL=2
-DESCRIPTION:Project:  Core Team meeting\nChair:  John Barker (gundalow)\nD
+RRULE:FREQ=MONTHLY;BYDAY=2TH
+DESCRIPTION:Project:  Core Team meeting\nChair:  Core Team\nD
  escription:  \nA place to get input from the Ansible Core Team issues\, PR
  s and proposals\nthat people who are willing to come to the meeting want t
  o present.\n- Old PRs that need attention from us (as opposed to from the

--- a/meetings/core-team.yaml
+++ b/meetings/core-team.yaml
@@ -2,7 +2,7 @@ project: Core Team meeting
 meeting_id: core
 project_url: https://github.com/ansible/community/wiki
 agenda_url: https://github.com/ansible/community/issues?q=is:open+label:meeting_agenda+label:core
-chair: John Barker (gundalow)
+chair: Core Team
 description: |
 
   A place to get input from the Ansible Core Team issues, PRs and proposals
@@ -12,13 +12,8 @@ description: |
   - Review of actions from previous meeting
   - Open discussion driven by the group
 schedule:
-- time: '1900'
-  day: Tuesday
-  irc: ansible-meeting
-  frequency: biweekly-odd
-  start_date: 20170201
-- time: '1500'
+- time: '1600'
   day: Thursday
   irc: ansible-meeting
-  frequency: biweekly-even
-  start_date: 20170201
+  frequency: second-thursday
+  start_date: 20220609

--- a/meetings/ical/core-team.ics
+++ b/meetings/ical/core-team.ics
@@ -3,38 +3,19 @@ VERSION:2.0
 PRODID:-//yaml2ical agendas//EN
 BEGIN:VEVENT
 SUMMARY:Core Team meeting
-DTSTART;VALUE=DATE-TIME:20170214T190000Z
+DTSTART;VALUE=DATE-TIME:20220714T160000Z
 DURATION:PT1H
-DTSTAMP;VALUE=DATE-TIME:20210324T163859Z
-UID:coreteammeeting-20170214
-RRULE:FREQ=WEEKLY;INTERVAL=2
-DESCRIPTION:Project:  Core Team meeting\nChair:  John Barker (gundalow)\nD
- escription:  \nA place to get input from the Ansible Core Team issues\, PR
- s and proposals\nthat people who are willing to come to the meeting want t
- o present.\n- Old PRs that need attention from us (as opposed to from the 
- submitter)\n- Selected proposals from the ansible/proposals repo\n- Review
-  of actions from previous meeting\n- Open discussion driven by the group\n
- \nAgenda URL:  https://github.com/ansible/community/issues?q=is:open+label
- :meeting_agenda+label:core\nProject URL:  https://github.com/ansible/commu
- nity/wiki
-LOCATION:#ansible-meeting
-END:VEVENT
-BEGIN:VEVENT
-SUMMARY:Core Team meeting
-DTSTART;VALUE=DATE-TIME:20170209T150000Z
-DURATION:PT1H
-DTSTAMP;VALUE=DATE-TIME:20210324T163859Z
-UID:coreteammeeting-20170209
-RRULE:FREQ=WEEKLY;INTERVAL=2
-DESCRIPTION:Project:  Core Team meeting\nChair:  John Barker (gundalow)\nD
- escription:  \nA place to get input from the Ansible Core Team issues\, PR
- s and proposals\nthat people who are willing to come to the meeting want t
- o present.\n- Old PRs that need attention from us (as opposed to from the 
- submitter)\n- Selected proposals from the ansible/proposals repo\n- Review
-  of actions from previous meeting\n- Open discussion driven by the group\n
- \nAgenda URL:  https://github.com/ansible/community/issues?q=is:open+label
- :meeting_agenda+label:core\nProject URL:  https://github.com/ansible/commu
- nity/wiki
+DTSTAMP;VALUE=DATE-TIME:20220613T110240Z
+UID:coreteammeeting-20220714
+RRULE:FREQ=MONTHLY;BYDAY=2TH
+DESCRIPTION:Project:  Core Team meeting\nChair:  Core Team\nDescription:  
+ \nA place to get input from the Ansible Core Team issues\, PRs and proposa
+ ls\nthat people who are willing to come to the meeting want to present.\n-
+  Old PRs that need attention from us (as opposed to from the submitter)\n-
+  Selected proposals from the ansible/proposals repo\n- Review of actions f
+ rom previous meeting\n- Open discussion driven by the group\n\nAgenda URL:
+   https://github.com/ansible/community/issues?q=is:open+label:meeting_agen
+ da+label:core\nProject URL:  https://github.com/ansible/community/wiki
 LOCATION:#ansible-meeting
 END:VEVENT
 END:VCALENDAR


### PR DESCRIPTION
This change moves the Core IRC meetings to happen once a month at 1600 UTC on the 2nd Thursday of the month.

If topics are more urgent, they can be brought up in advance in #ansible-devel