### PR TITLE
update DaWGs meeting for end of DST

### DIFF
--- a/ansible_community_meetings.ics
+++ b/ansible_community_meetings.ics
@@ -60,10 +60,10 @@ LOCATION:#ansible-meeting
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:Documentation working group
-DTSTART;VALUE=DATE-TIME:20220329T150000Z
+DTSTART;VALUE=DATE-TIME:20221108T160000Z
 DURATION:PT1H
-DTSTAMP;VALUE=DATE-TIME:20220323T113654Z
-UID:documentationworkinggroup-20220329
+DTSTAMP;VALUE=DATE-TIME:20220328T102806Z
+UID:documentationworkinggroup-20221108
 RRULE:FREQ=WEEKLY
 DESCRIPTION:Project:  Documentation working group\nChair:  Sandra McCann (
  samccann)\nDescription:  \nDiscuss everything related to Ansible Documenta

--- a/meetings/README.md
+++ b/meetings/README.md
@@ -31,7 +31,7 @@ You can add this full list of meetings to your personal calendar by importing by
   ([ical](https://raw.githubusercontent.com/ansible/community/main/meetings/ical/azure.ics))
   in `#ansible-azure`
 
-* [15:00 UTC](http://www.thetimezoneconverter.com/?t=15:00&tz=UTC):
+* [16:00 UTC](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC):
   **[Documentation Working Group](https://github.com/ansible/community/wiki/docs)**
   ([ical](https://raw.githubusercontent.com/ansible/community/main/meetings/ical/docs.ics))
   in `#ansible-docs`

--- a/meetings/docs.yaml
+++ b/meetings/docs.yaml
@@ -7,7 +7,7 @@ description: |
 
   Discuss everything related to Ansible Documentation.
 schedule:
-- time: '1500'
+- time: '1600'
   day: Tuesday
   irc: ansible-docs
   frequency: weekly

--- a/meetings/ical/docs.ics
+++ b/meetings/ical/docs.ics
@@ -3,10 +3,10 @@ VERSION:2.0
 PRODID:-//yaml2ical agendas//EN
 BEGIN:VEVENT
 SUMMARY:Documentation working group
-DTSTART;VALUE=DATE-TIME:20220329T150000Z
+DTSTART;VALUE=DATE-TIME:20221108T160000Z
 DURATION:PT1H
-DTSTAMP;VALUE=DATE-TIME:20220323T113654Z
-UID:documentationworkinggroup-20220329
+DTSTAMP;VALUE=DATE-TIME:20220328T102806Z
+UID:documentationworkinggroup-20221108
 RRULE:FREQ=WEEKLY
 DESCRIPTION:Project:  Documentation working group\nChair:  Sandra McCann (
  samccann)\nDescription:  \nDiscuss everything related to Ansible Documenta


### PR DESCRIPTION
Keeping the DaWGs meeting at its normal time (11am ET) after the time change.

Also need to change remindbot in matrix...
hange matrix reminder bot to move the DING DING DING reminder to 15:00 UTC (one hour before the meeting)
(something like !remindroom cron 0 15 * * 2 ; "DING DING DING! DaWGs (documentation working group meeting) happening in 1 hour") to happen at 1500 hrs on a Tuesday
(see https://github.com/anoadragon453/matrix-reminder-bot)