### PR TITLE
switch community meeting to 18:00 UTC

### DIFF
--- a/ansible_community_meetings.ics
+++ b/ansible_community_meetings.ics
@@ -54,10 +54,10 @@ LOCATION:#ansible-azure or https://matrix.to/#/#azure:ansible.com
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:Community working group
-DTSTART:20230201T190000Z
+DTSTART;VALUE=DATE-TIME:20230322T180000Z
 DURATION:PT1H
-DTSTAMP:20211013T124637Z
-UID:communityworkinggroup-20230201
+DTSTAMP;VALUE=DATE-TIME:20230201T040348Z
+UID:communityworkinggroup-20230322
 RRULE:FREQ=WEEKLY
 DESCRIPTION:Project:  Community working group\nChair:  John Barker (gundal
  ow)\nDescription:  \nDiscuss everything related to Ansible Community and C

--- a/meetings/community.yaml
+++ b/meetings/community.yaml
@@ -7,7 +7,7 @@ description: |
 
     Discuss everything related to Ansible Community and Contributor experience.
 schedule:
-- time: '1900'
+- time: '1800'
   day: Wednesday
   irc: ansible-community or https://matrix.to/#/#community:ansible.com
   frequency: weekly

--- a/meetings/ical/community.ics
+++ b/meetings/ical/community.ics
@@ -3,10 +3,10 @@ VERSION:2.0
 PRODID:-//yaml2ical agendas//EN
 BEGIN:VEVENT
 SUMMARY:Community working group
-DTSTART:20230201T190000Z
+DTSTART;VALUE=DATE-TIME:20230322T180000Z
 DURATION:PT1H
-DTSTAMP:20211013T124637Z
-UID:communityworkinggroup-20230201
+DTSTAMP;VALUE=DATE-TIME:20230201T040348Z
+UID:communityworkinggroup-20230322
 RRULE:FREQ=WEEKLY
 DESCRIPTION:Project:  Community working group\nChair:  John Barker (gundal
  ow)\nDescription:  \nDiscuss everything related to Ansible Community and C


### PR DESCRIPTION
Summer time begins for (most of) the Europe on 26 March. It started in the US back on 12 March. After last time change, we informally agreed to move the meeting according to winter and summer time (i.e. meet at 19:00 in the winter and 18:00 in the summer).