### PR TITLE
Shift DaWGs meeting to DST

### DIFF
--- a/ansible_community_meetings.ics
+++ b/ansible_community_meetings.ics
@@ -85,10 +85,10 @@ LOCATION:#ansible-meeting
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:Documentation working group
-DTSTART:20230131T160000Z
+DTSTART;VALUE=DATE-TIME:20230328T150000Z
 DURATION:PT1H
-DTSTAMP:20211013T124637Z
-UID:documentationworkinggroup-20230131
+DTSTAMP;VALUE=DATE-TIME:20230201T040348Z
+UID:documentationworkinggroup-20230328
 RRULE:FREQ=WEEKLY
 DESCRIPTION:Project:  Documentation working group\nChair:  Sandra McCann (
  samccann)\nDescription:  \nDiscuss everything related to Ansible Documenta

--- a/meetings/README.md
+++ b/meetings/README.md
@@ -31,7 +31,7 @@ Note that many of the working groups below have Matrix rooms bridged with the me
   ([ical](https://raw.githubusercontent.com/ansible/community/main/meetings/ical/azure.ics))
   in `#ansible-azure` [IRC](https://docs.ansible.com/ansible/devel/community/communication.html#ansible-community-on-irc) | [#azure:ansible.com)](https://matrix.to/#/#azure:ansible.com) [Matrix](https://docs.ansible.com/ansible/devel/community/communication.html#ansible-community-on-matrix)
 
-* [16:00 UTC](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC):
+* [15:00 UTC](http://www.thetimezoneconverter.com/?t=15:00&tz=UTC):
   **[Documentation Working Group](https://github.com/ansible/community/wiki/docs)**
   ([ical](https://raw.githubusercontent.com/ansible/community/main/meetings/ical/docs.ics))
   in `#ansible-docs` [IRC](https://docs.ansible.com/ansible/devel/community/communication.html#ansible-community-on-irc) | [#docs:ansible.com](https://matrix.to/#/#docs:ansible.com) [Matrix](https://docs.ansible.com/ansible/devel/community/communication.html#ansible-community-on-matrix)

--- a/meetings/docs.yaml
+++ b/meetings/docs.yaml
@@ -7,7 +7,7 @@ description: |
 
   Discuss everything related to Ansible Documentation.
 schedule:
-- time: '1600'
+- time: '1500'
   day: Tuesday
   irc: ansible-docs or https://matrix.to/#/#docs:ansible.com
   frequency: weekly

--- a/meetings/ical/docs.ics
+++ b/meetings/ical/docs.ics
@@ -3,10 +3,10 @@ VERSION:2.0
 PRODID:-//yaml2ical agendas//EN
 BEGIN:VEVENT
 SUMMARY:Documentation working group
-DTSTART:20230131T160000Z
+DTSTART;VALUE=DATE-TIME:20230328T150000Z
 DURATION:PT1H
-DTSTAMP:20211013T124637Z
-UID:documentationworkinggroup-20230131
+DTSTAMP;VALUE=DATE-TIME:20230201T040348Z
+UID:documentationworkinggroup-20230328
 RRULE:FREQ=WEEKLY
 DESCRIPTION:Project:  Documentation working group\nChair:  Sandra McCann (
  samccann)\nDescription:  \nDiscuss everything related to Ansible Documenta


### PR DESCRIPTION
Time to shift the meeting again to 15:00 UTC to account for daylight savings changes. This brings the meeting back to it's 'usual' time for places that have already shifted to daylight savings time