### PR TITLE
Shift networking meeting time

### DIFF
--- a/ansible_community_meetings.ics
+++ b/ansible_community_meetings.ics
@@ -99,11 +99,11 @@ LOCATION:#ansible-docs or https://matrix.to/#/#docs:ansible.com
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:Network working group
-DTSTART:20230201T160000Z
+DTSTART:20230427T130000Z
 DURATION:PT1H
-DTSTAMP:20211013T124637Z
-UID:networkworkinggroup-20230201
-RRULE:FREQ=WEEKLY
+DTSTAMP:20230201T040348Z
+UID:networkworkinggroup-20230427
+RRULE:FREQ=WEEKLY;INTERVAL=2
 DESCRIPTION:Project:  Network working group\nChair:  Kate Case (Qalthos)\n
  Description:  \nDiscuss everything network.\n\nAgenda URL:  https://github
  .com/ansible/community/labels/network\nProject URL:  https://github.com/an

--- a/ansible_community_meetings.ics
+++ b/ansible_community_meetings.ics
@@ -99,10 +99,10 @@ LOCATION:#ansible-docs or https://matrix.to/#/#docs:ansible.com
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:Network working group
-DTSTART:20230427T130000Z
+DTSTART:20230511T130000Z
 DURATION:PT1H
-DTSTAMP:20230201T040348Z
-UID:networkworkinggroup-20230427
+DTSTAMP:20230428T111440Z
+UID:networkworkinggroup-20230511
 RRULE:FREQ=WEEKLY;INTERVAL=2
 DESCRIPTION:Project:  Network working group\nChair:  Kate Case (Qalthos)\n
  Description:  \nDiscuss everything network.\n\nAgenda URL:  https://github

--- a/ansible_community_meetings.ics
+++ b/ansible_community_meetings.ics
@@ -128,18 +128,34 @@ LOCATION:#ansible-vmware or https://matrix.to/#/#vmware:ansible.com
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:Windows working group
-DTSTART:20230131T200000Z
+DTSTART:20230502T200000Z
 DURATION:PT1H
-DTSTAMP:20211013T124637Z
-UID:windowsworkinggroup-20230131
-RRULE:FREQ=WEEKLY
+DTSTAMP:20230428T112052Z
+UID:windowsworkinggroup-20230502
+RRULE:FREQ=MONTHLY;BYDAY=1TU
 DESCRIPTION:Project:  Windows working group\nChair:  Matt Davis (nitzmahon
  e)\, Jordan Borean (jborean93)\nDescription:  \nWe discuss everything Wind
- ows every week on Tuesday.\n\nIf you have something to discuss (e.g. a PR 
- that needs help)\, add your\nrequest to the meeting agenda and join the IR
- C channel.\n\nAgenda URL:  https://github.com/ansible/community/issues?q=i
- s:open+label:meeting_agenda+label:windows\nProject URL:  https://github.co
- m/ansible/community/wiki/Windows
+ ows every 1st and 3rd Tuesday.\n\nIf you have something to discuss (e.g. a
+  PR that needs help)\, add your\nrequest to the meeting agenda and join th
+ e IRC channel.\n\nAgenda URL:  https://github.com/ansible/community/issues
+ ?q=is:open+label:meeting_agenda+label:windows\nProject URL:  https://githu
+ b.com/ansible/community/wiki/Windows
+LOCATION:#ansible-windows or https://matrix.to/#/#windows:ansible.com
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Windows working group
+DTSTART:20230516T200000Z
+DURATION:PT1H
+DTSTAMP:20230428T112052Z
+UID:windowsworkinggroup-20230516
+RRULE:FREQ=MONTHLY;BYDAY=3TU
+DESCRIPTION:Project:  Windows working group\nChair:  Matt Davis (nitzmahon
+ e)\, Jordan Borean (jborean93)\nDescription:  \nWe discuss everything Wind
+ ows every 1st and 3rd Tuesday.\n\nIf you have something to discuss (e.g. a
+  PR that needs help)\, add your\nrequest to the meeting agenda and join th
+ e IRC channel.\n\nAgenda URL:  https://github.com/ansible/community/issues
+ ?q=is:open+label:meeting_agenda+label:windows\nProject URL:  https://githu
+ b.com/ansible/community/wiki/Windows
 LOCATION:#ansible-windows or https://matrix.to/#/#windows:ansible.com
 END:VEVENT
 END:VCALENDAR

--- a/meetings/README.md
+++ b/meetings/README.md
@@ -43,17 +43,17 @@ Note that many of the working groups below have Matrix rooms bridged with the me
 
 ### Wednesdays
 
-* [16:00 UTC](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC):
-  **[Network Working Group](https://github.com/ansible/community/wiki/network)**
-  ([ical](https://raw.githubusercontent.com/ansible/community/main/meetings/ical/network.ics))
-  in `#ansible-network` [IRC](https://docs.ansible.com/ansible/devel/community/communication.html#ansible-community-on-irc) | [#network:ansible.com](https://matrix.to/#/#network:ansible.com) [Matrix](https://docs.ansible.com/ansible/devel/community/communication.html#ansible-community-on-matrix)
-
 * [19:00 UTC](http://www.thetimezoneconverter.com/?t=19:00&tz=UTC):
   **[Community Working Group](https://github.com/ansible/community/issues/539)**
   ([ical](https://raw.githubusercontent.com/ansible/community/main/meetings/ical/community.ics))
   in `#ansible-community` [IRC](https://docs.ansible.com/ansible/devel/community/communication.html#ansible-community-on-irc) | [#community:ansible.com](https://matrix.to/#/#community:ansible.com) [Matrix](https://docs.ansible.com/ansible/devel/community/communication.html#ansible-community-on-matrix)
 
 ### Thursdays
+
+* [13:00 UTC](http://www.thetimezoneconverter.com/?t=13:00&tz=UTC):
+  **[Network Working Group](https://github.com/ansible/community/wiki/network)**
+  ([ical](https://raw.githubusercontent.com/ansible/community/main/meetings/ical/network.ics))
+  in `#ansible-network` [IRC](https://docs.ansible.com/ansible/devel/community/communication.html#ansible-community-on-irc) | [#network:ansible.com](https://matrix.to/#/#network:ansible.com) [Matrix](https://docs.ansible.com/ansible/devel/community/communication.html#ansible-community-on-matrix)
 
 * [15:00 UTC](http://www.thetimezoneconverter.com/?t=15:00&tz=UTC):
   **Core Team Meeting**

--- a/meetings/README.md
+++ b/meetings/README.md
@@ -26,7 +26,7 @@ Note that many of the working groups below have Matrix rooms bridged with the me
 
 ### Tuesdays
 
-* [13:00 UTC](http://www.thetimezoneconverter.com/?t=00:00&tz=UTC):
+* [13:00 UTC](http://www.thetimezoneconverter.com/?t=13:00&tz=UTC):
   **[Azure Working Group](https://github.com/ansible/community/wiki/azure)**
   ([ical](https://raw.githubusercontent.com/ansible/community/main/meetings/ical/azure.ics))
   in `#ansible-azure` [IRC](https://docs.ansible.com/ansible/devel/community/communication.html#ansible-community-on-irc) | [#azure:ansible.com)](https://matrix.to/#/#azure:ansible.com) [Matrix](https://docs.ansible.com/ansible/devel/community/communication.html#ansible-community-on-matrix)

--- a/meetings/ical/network.ics
+++ b/meetings/ical/network.ics
@@ -3,10 +3,10 @@ VERSION:2.0
 PRODID:-//yaml2ical agendas//EN
 BEGIN:VEVENT
 SUMMARY:Network working group
-DTSTART:20230427T130000Z
+DTSTART:20230511T130000Z
 DURATION:PT1H
-DTSTAMP:20230201T040348Z
-UID:networkworkinggroup-20230427
+DTSTAMP:20230428T111440Z
+UID:networkworkinggroup-20230511
 RRULE:FREQ=WEEKLY;INTERVAL=2
 DESCRIPTION:Project:  Network working group\nChair:  Kate Case (Qalthos)\n
  Description:  \nDiscuss everything network.\n\nAgenda URL:  https://github

--- a/meetings/ical/network.ics
+++ b/meetings/ical/network.ics
@@ -3,11 +3,11 @@ VERSION:2.0
 PRODID:-//yaml2ical agendas//EN
 BEGIN:VEVENT
 SUMMARY:Network working group
-DTSTART:20230201T160000Z
+DTSTART:20230427T130000Z
 DURATION:PT1H
-DTSTAMP:20211013T124637Z
-UID:networkworkinggroup-20230201
-RRULE:FREQ=WEEKLY
+DTSTAMP:20230201T040348Z
+UID:networkworkinggroup-20230427
+RRULE:FREQ=WEEKLY;INTERVAL=2
 DESCRIPTION:Project:  Network working group\nChair:  Kate Case (Qalthos)\n
  Description:  \nDiscuss everything network.\n\nAgenda URL:  https://github
  .com/ansible/community/labels/network\nProject URL:  https://github.com/an

--- a/meetings/ical/windows.ics
+++ b/meetings/ical/windows.ics
@@ -3,19 +3,34 @@ VERSION:2.0
 PRODID:-//yaml2ical agendas//EN
 BEGIN:VEVENT
 SUMMARY:Windows working group
-DTSTART:20230404T200000Z
+DTSTART:20230502T200000Z
 DURATION:PT1H
-DTSTAMP:20211013T124637Z
-LAST-MODIFIED:20230403T202000Z
-UID:windowsworkinggroup-20230131
-RRULE:FREQ=MONTHLY;BYDAY=1TU,3TU
+DTSTAMP:20230428T112052Z
+UID:windowsworkinggroup-20230502
+RRULE:FREQ=MONTHLY;BYDAY=1TU
 DESCRIPTION:Project:  Windows working group\nChair:  Matt Davis (nitzmahon
  e)\, Jordan Borean (jborean93)\nDescription:  \nWe discuss everything Wind
- ows every 1st and 3rd Tuesday.\n\nIf you have something to discuss (e.g. a PR 
- that needs help)\, add your\nrequest to the meeting agenda and join the IR
- C channel.\n\nAgenda URL:  https://github.com/ansible/community/issues?q=i
- s:open+label:meeting_agenda+label:windows\nProject URL:  https://github.co
- m/ansible/community/wiki/Windows
+ ows every 1st and 3rd Tuesday.\n\nIf you have something to discuss (e.g. a
+  PR that needs help)\, add your\nrequest to the meeting agenda and join th
+ e IRC channel.\n\nAgenda URL:  https://github.com/ansible/community/issues
+ ?q=is:open+label:meeting_agenda+label:windows\nProject URL:  https://githu
+ b.com/ansible/community/wiki/Windows
+LOCATION:#ansible-windows or https://matrix.to/#/#windows:ansible.com
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Windows working group
+DTSTART:20230516T200000Z
+DURATION:PT1H
+DTSTAMP:20230428T112052Z
+UID:windowsworkinggroup-20230516
+RRULE:FREQ=MONTHLY;BYDAY=3TU
+DESCRIPTION:Project:  Windows working group\nChair:  Matt Davis (nitzmahon
+ e)\, Jordan Borean (jborean93)\nDescription:  \nWe discuss everything Wind
+ ows every 1st and 3rd Tuesday.\n\nIf you have something to discuss (e.g. a
+  PR that needs help)\, add your\nrequest to the meeting agenda and join th
+ e IRC channel.\n\nAgenda URL:  https://github.com/ansible/community/issues
+ ?q=is:open+label:meeting_agenda+label:windows\nProject URL:  https://githu
+ b.com/ansible/community/wiki/Windows
 LOCATION:#ansible-windows or https://matrix.to/#/#windows:ansible.com
 END:VEVENT
 END:VCALENDAR

--- a/meetings/network.yaml
+++ b/meetings/network.yaml
@@ -8,6 +8,7 @@ description: |
   Discuss everything network.
 schedule:
 - time: '1300'
+  start_date: 20230511
   day: Thursday
   irc: ansible-network or https://matrix.to/#/#network:ansible.com
   frequency: biweekly-odd

--- a/meetings/network.yaml
+++ b/meetings/network.yaml
@@ -7,7 +7,7 @@ description: |
 
   Discuss everything network.
 schedule:
-- time: '1600'
-  day: Wednesday
+- time: '1300'
+  day: Thursday
   irc: ansible-network or https://matrix.to/#/#network:ansible.com
-  frequency: weekly
+  frequency: biweekly-odd

--- a/meetings/windows.yaml
+++ b/meetings/windows.yaml
@@ -5,7 +5,7 @@ agenda_url: https://github.com/ansible/community/issues?q=is:open+label:meeting_
 chair: Matt Davis (nitzmahone), Jordan Borean (jborean93)
 description: |
 
-  We discuss everything Windows every week on Tuesday.
+  We discuss everything Windows every 1st and 3rd Tuesday.
 
   If you have something to discuss (e.g. a PR that needs help), add your
   request to the meeting agenda and join the IRC channel.
@@ -13,4 +13,8 @@ schedule:
 - time: '2000'
   day: Tuesday
   irc: ansible-windows or https://matrix.to/#/#windows:ansible.com
-  frequency: weekly
+  frequency: first-tuesday
+- time: '2000'
+  day: Tuesday
+  irc: ansible-windows or https://matrix.to/#/#windows:ansible.com
+  frequency: third-tuesday


### PR DESCRIPTION
This also fixes the Windows meeting definition so that the calendars generate properly, and fixes the remainder of #656 since I had to edit that list anyway.