### PR TITLE
update Docs meeting for end of daylight savings time

### DIFF
--- a/ansible_community_meetings.ics
+++ b/ansible_community_meetings.ics
@@ -68,16 +68,16 @@ LOCATION:#ansible-community or https://matrix.to/#/#community:ansible.com
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:Documentation working group
-DTSTART;VALUE=DATE-TIME:20230328T150000Z
+DTSTART:20231107T160000Z
 DURATION:PT1H
-DTSTAMP;VALUE=DATE-TIME:20230201T040348Z
-UID:documentationworkinggroup-20230328
+DTSTAMP:20230327T150934Z
+UID:documentationworkinggroup-20231107
 RRULE:FREQ=WEEKLY
 DESCRIPTION:Project:  Documentation working group\nChair:  Sandra McCann (
  samccann)\nDescription:  \nDiscuss everything related to Ansible Documenta
- tion.\n\nAgenda URL:  https://github.com/ansible/community/issues?q=is:ope
- n+label:meeting_agenda+label:docs\nProject URL:  https://github.com/ansibl
- e/community/wiki/Docs
+ tion.\n\nAgenda URL:  https://forum.ansible.com/t/documentation-working-gr
+ oup-agenda/153/7\nProject URL:  https://github.com/ansible/community/wiki/
+ Docs
 LOCATION:#ansible-docs or https://matrix.to/#/#docs:ansible.com
 END:VEVENT
 BEGIN:VEVENT

--- a/meetings/README.md
+++ b/meetings/README.md
@@ -31,7 +31,7 @@ Note that many of the working groups below have Matrix rooms bridged with the me
   ([ical](https://raw.githubusercontent.com/ansible/community/main/meetings/ical/azure.ics))
   in `#ansible-azure` [IRC](https://docs.ansible.com/ansible/devel/community/communication.html#ansible-community-on-irc) | [#azure:ansible.com)](https://matrix.to/#/#azure:ansible.com) [Matrix](https://docs.ansible.com/ansible/devel/community/communication.html#ansible-community-on-matrix)
 
-* [15:00 UTC](http://www.thetimezoneconverter.com/?t=15:00&tz=UTC):
+* [16:00 UTC](http://www.thetimezoneconverter.com/?t=16:00&tz=UTC):
   **[Documentation Working Group](https://github.com/ansible/community/wiki/docs)**
   ([ical](https://raw.githubusercontent.com/ansible/community/main/meetings/ical/docs.ics))
   in `#ansible-docs` [IRC](https://docs.ansible.com/ansible/devel/community/communication.html#ansible-community-on-irc) | [#docs:ansible.com](https://matrix.to/#/#docs:ansible.com) [Matrix](https://docs.ansible.com/ansible/devel/community/communication.html#ansible-community-on-matrix)

--- a/meetings/docs.yaml
+++ b/meetings/docs.yaml
@@ -1,13 +1,13 @@
 project: Documentation working group
 meeting_id: docs
 project_url: https://github.com/ansible/community/wiki/Docs
-agenda_url: https://github.com/ansible/community/issues?q=is:open+label:meeting_agenda+label:docs
+agenda_url: https://forum.ansible.com/t/documentation-working-group-agenda/153/7
 chair: Sandra McCann (samccann)
 description: |
 
   Discuss everything related to Ansible Documentation.
 schedule:
-- time: '1500'
+- time: '1600'
   day: Tuesday
   irc: ansible-docs or https://matrix.to/#/#docs:ansible.com
   frequency: weekly

--- a/meetings/ical/docs.ics
+++ b/meetings/ical/docs.ics
@@ -3,16 +3,16 @@ VERSION:2.0
 PRODID:-//yaml2ical agendas//EN
 BEGIN:VEVENT
 SUMMARY:Documentation working group
-DTSTART;VALUE=DATE-TIME:20230328T150000Z
+DTSTART:20231107T160000Z
 DURATION:PT1H
-DTSTAMP;VALUE=DATE-TIME:20230201T040348Z
-UID:documentationworkinggroup-20230328
+DTSTAMP:20230327T150934Z
+UID:documentationworkinggroup-20231107
 RRULE:FREQ=WEEKLY
 DESCRIPTION:Project:  Documentation working group\nChair:  Sandra McCann (
  samccann)\nDescription:  \nDiscuss everything related to Ansible Documenta
- tion.\n\nAgenda URL:  https://github.com/ansible/community/issues?q=is:ope
- n+label:meeting_agenda+label:docs\nProject URL:  https://github.com/ansibl
- e/community/wiki/Docs
+ tion.\n\nAgenda URL:  https://forum.ansible.com/t/documentation-working-gr
+ oup-agenda/153/7\nProject URL:  https://github.com/ansible/community/wiki/
+ Docs
 LOCATION:#ansible-docs or https://matrix.to/#/#docs:ansible.com
 END:VEVENT
 END:VCALENDAR


### PR DESCRIPTION
Also updated the agenda link to point to the forum now.

Steps to implement:

    update docs.yaml
    ~/community/meetings (dawgs-dst) $ make all
   `git checkout HEAD` to  revert the other files and other entries in ansible_community_meetings.ics
